### PR TITLE
Allow for UART mode exclusively on TMC2209.  pass -1 to STEP and DIR

### DIFF
--- a/components/stepper_driver/src/stepper_driver_tmc2208.c
+++ b/components/stepper_driver/src/stepper_driver_tmc2208.c
@@ -35,14 +35,22 @@ esp_err_t tmc2208_init(stepper_driver_t *handle)
     esp_err_t ret = ESP_OK;
     stepper_driver_tmc2208_t *tmc2208 = __containerof(handle, stepper_driver_tmc2208_t, parent);
 
-    gpio_reset_pin(tmc2208->driver_config.step_pin);
-    gpio_reset_pin(tmc2208->driver_config.direction_pin);
+    if (tmc2208->driver_config.step_pin >= 0) {
+        gpio_reset_pin(tmc2208->driver_config.step_pin);
+    }
+    if (tmc2208->driver_config.direction_pin >= 0) {
+        gpio_reset_pin(tmc2208->driver_config.direction_pin);
+    }
     gpio_reset_pin(tmc2208->driver_config.enable_pin);
     gpio_reset_pin(tmc2208->driver_config.rx_pin);
     gpio_reset_pin(tmc2208->driver_config.tx_pin);
 
-    gpio_set_direction(tmc2208->driver_config.step_pin, GPIO_MODE_OUTPUT);
-    gpio_set_direction(tmc2208->driver_config.direction_pin, GPIO_MODE_OUTPUT);
+    if (tmc2208->driver_config.step_pin >= 0) {
+        gpio_set_direction(tmc2208->driver_config.step_pin, GPIO_MODE_OUTPUT);
+    }
+    if (tmc2208->driver_config.direction_pin >= 0) {
+        gpio_set_direction(tmc2208->driver_config.direction_pin, GPIO_MODE_OUTPUT);
+    }
     gpio_set_direction(tmc2208->driver_config.enable_pin, GPIO_MODE_OUTPUT);
     gpio_set_direction(tmc2208->driver_config.rx_pin, GPIO_MODE_INPUT);
     gpio_set_direction(tmc2208->driver_config.tx_pin, GPIO_MODE_OUTPUT);


### PR DESCRIPTION
I'm using your driver with my TMC2209 chip. Works perfectly by the way! However, I'm using exclusively UART mode. As a result, I do not need the STEP or DIR pins connected, nor defined.  the ESP-IDF library, does not allow for "invalid" pins to be defined when setting up the pads.  Instead of picking unused, but valid pins on my esp32, I modifed your driver to allow for -1 STEP and DIR pins.

Use this code however you see fit. Merge it into your branch? Or, do it your own way.  It's all good.

P.S. the 2209 has a few extra features compared to the 2208. One of which is the "stall" output pin (diag).   Another is `Stallguard` and `Coolstep`.  Both features I'd like to use in my project. Time permitting, I might see if I can add the functionality to your TMC2208 code, extended with a 2209 driver variant.  Alas, working with the TMC UART is pretty new to me.

Cheers