### PR TITLE
ESP-IDF v5.x compatibility fix

### DIFF
--- a/components/stepper_driver/stepper_driver_tmc2208.c
+++ b/components/stepper_driver/stepper_driver_tmc2208.c
@@ -85,7 +85,7 @@ esp_err_t tmc2208_init(stepper_driver_t *handle)
     // ---- Configure RMT ----
     rmt_tx_channel_config_t tx_chan_config = {
         .gpio_num = tmc2208->driver_config.step_pin,
-        .clk_src = RMT_CLK_SRC_REF_TICK, // wählt automatisch eine passende Taktquelle
+        .clk_src = RMT_CLK_SRC_DEFAULT, // wählt automatisch eine passende Taktquelle
         .resolution_hz = 1000000, // 1 MHz Auflösung, 1 Tick = 1 µs
         .mem_block_symbols = RMT_BLOCK_SIZE, // Größe des Speicherblocks
         .trans_queue_depth = 4, // Tiefe der Transaktions-Warteschlange


### PR DESCRIPTION
# ESP-IDF v5.x Compatibility Fix

## Problem

The library fails to compile on ESP-IDF v5.x with the following error:

```
stepper_driver_tmc2208.c:88:20: error: 'RMT_CLK_SRC_REF_TICK' undeclared (first use in this function); did you mean 'RMT_CLK_SRC_DEFAULT'?
   88 |         .clk_src = RMT_CLK_SRC_REF_TICK,
      |                    ^~~~~~~~~~~~~~~~~~~~
      |                    RMT_CLK_SRC_DEFAULT
```

The `RMT_CLK_SRC_REF_TICK` clock source was removed in ESP-IDF v5.x as part of the RMT driver refactoring.

## Fix

**File:** `components/stepper_driver/stepper_driver_tmc2208.c`

**Line 88:** Change the RMT clock source from the deprecated constant to the default:

```diff
    rmt_tx_channel_config_t tx_chan_config = {
        .gpio_num = tmc2208->driver_config.step_pin,
-       .clk_src = RMT_CLK_SRC_REF_TICK, // wählt automatisch eine passende Taktquelle
+       .clk_src = RMT_CLK_SRC_DEFAULT,
        .resolution_hz = 1000000, // 1 MHz Auflösung, 1 Tick = 1 µs
        .mem_block_symbols = RMT_BLOCK_SIZE, // Größe des Speicherblocks
        .trans_queue_depth = 4, // Tiefe der Transaktions-Warteschlange
    };
```

`RMT_CLK_SRC_DEFAULT` lets the driver pick an appropriate clock source automatically, which works across ESP-IDF v4.x and v5.x.

## Tested On

- ESP-IDF v5.5.2
- ESP32-S3

## References

- ESP-IDF RMT Driver Migration Guide: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/migration-guides/release-5.x/5.0/peripherals.html
