### PR TITLE
microstep ENUM bug fix

### DIFF
--- a/components/stepper_driver/include/stepper_driver.h
+++ b/components/stepper_driver/include/stepper_driver.h
@@ -4,15 +4,15 @@
 
 
 typedef enum {
-    MICROSTEPS_1 =   0,
-    MICROSTEPS_2   = 1,
-    MICROSTEPS_4   = 2,
-    MICROSTEPS_8   = 3,
+    MICROSTEPS_256 = 0,
+    MICROSTEPS_128 = 1,
+    MICROSTEPS_64  = 2,
+    MICROSTEPS_32  = 3,
     MICROSTEPS_16  = 4,
-    MICROSTEPS_32  = 5,
-    MICROSTEPS_64  = 6,
-    MICROSTEPS_128 = 7,
-    MICROSTEPS_256 = 8
+    MICROSTEPS_8   = 5,
+    MICROSTEPS_4   = 6,
+    MICROSTEPS_2   = 7,
+    MICROSTEPS_1   = 8
 } stepper_driver_microsteps_t;
 
 


### PR DESCRIPTION
# Microstep Enum Bug Fix

## Problem

The microstep enum values in `stepper_driver.h` are inverted from the TMC2208 MRES register encoding. This causes incorrect microstep settings when using values other than 16 microsteps (which works by coincidence).

**Symptom:** Setting 8 microsteps results in 32 microsteps on the driver, causing the motor to rotate only 1/4 of the expected distance.

## Root Cause

The library defines:

```c
typedef enum {
    MICROSTEPS_1 =   0,    // Bug: Should be 8
    MICROSTEPS_2   = 1,    // Bug: Should be 7
    MICROSTEPS_4   = 2,    // Bug: Should be 6
    MICROSTEPS_8   = 3,    // Bug: Should be 5
    MICROSTEPS_16  = 4,    // Correct by coincidence
    MICROSTEPS_32  = 5,    // Bug: Should be 3
    MICROSTEPS_64  = 6,    // Bug: Should be 2
    MICROSTEPS_128 = 7,    // Bug: Should be 1
    MICROSTEPS_256 = 8     // Bug: Should be 0
} stepper_driver_microsteps_t;
```

But the TMC2208 MRES register encoding is:

| MRES value | Microsteps |
|------------|------------|
| 0 | 256 |
| 1 | 128 |
| 2 | 64 |
| 3 | 32 |
| 4 | 16 |
| 5 | 8 |
| 6 | 4 |
| 7 | 2 |
| 8 | 1 (full step) |

The enum values are inverted - higher microstep counts should have lower MRES values.

## Fix

**File:** `include/stepper_driver.h`

**Lines 7-15:** Replace the enum with the correct TMC2208 MRES encoding:

```diff
 typedef enum {
-    MICROSTEPS_1 =   0,
-    MICROSTEPS_2   = 1,
-    MICROSTEPS_4   = 2,
-    MICROSTEPS_8   = 3,
-    MICROSTEPS_16  = 4,
-    MICROSTEPS_32  = 5,
-    MICROSTEPS_64  = 6,
-    MICROSTEPS_128 = 7,
-    MICROSTEPS_256 = 8
+    MICROSTEPS_256 = 0,
+    MICROSTEPS_128 = 1,
+    MICROSTEPS_64  = 2,
+    MICROSTEPS_32  = 3,
+    MICROSTEPS_16  = 4,
+    MICROSTEPS_8   = 5,
+    MICROSTEPS_4   = 6,
+    MICROSTEPS_2   = 7,
+    MICROSTEPS_1   = 8
 } stepper_driver_microsteps_t;
```

## Verification

After the fix, reading back CHOPCONF should show the correct MRES value:

| Config Setting | Expected MRES | Actual Microsteps |
|----------------|---------------|-------------------|
| MICROSTEPS_8 | 5 | 8 |
| MICROSTEPS_16 | 4 | 16 |
| MICROSTEPS_32 | 3 | 32 |

## Tested On

- ESP-IDF v5.5.2
- ESP32-S3
- TMC2208 stepper driver
